### PR TITLE
XS✔ ◾ Enhancing security: Reducing pipeline permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ on:
   schedule:
     - cron: 0 0 * * 1
 
-permissions: read-all
+permissions: {}
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -108,7 +108,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -164,7 +164,7 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -323,7 +323,7 @@ jobs:
   validate-linter:
     name: Validate – Linter
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/release-phase-1-internal.yml
+++ b/.github/workflows/release-phase-1-internal.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/release-phase-1.yml
+++ b/.github/workflows/release-phase-1.yml
@@ -27,13 +27,13 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions: {}
 
 jobs:
   release:
     uses: ./.github/workflows/release-phase-1-internal.yml
     secrets: inherit
-    permissions: read-all
+    permissions: {}
     with:
       major: ${{ inputs.major || 1 }}
       minor: ${{ inputs.minor || 5 }}

--- a/.github/workflows/release-phase-2.yml
+++ b/.github/workflows/release-phase-2.yml
@@ -12,13 +12,13 @@ on:
     paths:
       - .github/workflows/support/release-trigger.txt
 
-permissions: read-all
+permissions: {}
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION
## Summary

### Motivation

To enhance security, permissions of jobs within the GitHub pipelines should be minimised as far as possible.

### Technical

Changing `read-all` permissions to `{}`, which corresponds to no permissions. Permissions that are required - including read permissions - are explicitly set on the relevant jobs.