### PR TITLE
XS✔ ◾ Pipeline Compliance: Adding CredScan Suppression

### DIFF
--- a/.github/azure-devops/CredScanSuppressions.json
+++ b/.github/azure-devops/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "hash": "BLCOsUjFMDMIRVkA0Pr09Mw0rkfUJmTGNGadmYYeAK8=",
+      "_justification": "Incorrectly identified secret within minified JSON."
+    }
+  ]
+}

--- a/.github/azure-devops/pr.yml
+++ b/.github/azure-devops/pr.yml
@@ -29,6 +29,8 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         os: windows
         image: windows-latest
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.github\azure-devops\CredScanSuppressions.json
       eslint:
         environmentsEs2017: true
         environmentsMocha: true

--- a/.github/azure-devops/prod.yml
+++ b/.github/azure-devops/prod.yml
@@ -30,6 +30,8 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         os: windows
         image: windows-latest
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.github\azure-devops\CredScanSuppressions.json
       eslint:
         environmentsEs2017: true
         environmentsMocha: true


### PR DESCRIPTION
## Summary

### Motivation

CredScan is erroneously detecting a secret within a file of minified JSON, which is required within the repo to support GitHub Actions. This was only seen once the previous PR was committed and the pipelines ran against the `main` branch.

### Technical

Adding a new CredScan suppressions file with the appropriate suppression and explanation.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests