### PR TITLE
XS✔ ◾ Fixing build task "Validate .markdownlint.json"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,7 @@ jobs:
           files: .markdownlint.json
           print-valid-files: true
           schema: .markdownlint.schema.json
+          strict: false
 
       - name: Validate package.json – Download package.schema.json
         shell: pwsh


### PR DESCRIPTION
## Summary

### Motivation

The build has started to fail on the task "Validate .markdownlint.json".

### Technical

The issue has been fixed by passing `strict: false` to the JSON validation task. This is now required because <https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json> was recently updated to add an `$id` element, which is unsupported by the `walbo/validate-json` action.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests

### Unit Test Coverage

100%