### PR TITLE
Build Fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
         run: |-
           $FileContent = Get-Content -Path 'package.schema.json' -Raw
           $FileContent = $FileContent -replace ',\s+".+": {\s+"\$ref": "https:\/\/json\.schemastore\.org\/.+\s+}', ''
+          $FileContent = $FileContent -replace 'http://json-schema.org/draft-07/schema#', 'http://json-schema.org/draft-04/schema#'
           Set-Content -NoNewline -Path 'package.schema.json' -Value $FileContent
 
       - name: Validate package.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
       - main
   schedule:
     - cron: 0 0 * * 1
+  workflow_dispatch: null
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

### Motivation

Following recent changes to <https://json.schemastore.org/package.json>, the main build loop started to fail.

### Technical

Updating the contents of the `package.json` file to downgrade the JSON schema to a supported version, as per the previous iteration of the file.

This change also adds `workflow_dispatch` to the build workflow, to allow it to be run manually if required for testing.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests

### Unit Test Coverage

100%