### PR TITLE
XS✔ ◾ ADO Pipelines: Secure Variables Change

### DIFF
--- a/.github/azure-devops/pr-test.yml
+++ b/.github/azure-devops/pr-test.yml
@@ -13,6 +13,7 @@ pr:
 variables:
   - name: tags
     value: multi-phased
+  - group: PR Metrics
 
 stages:
   - template: template.yml

--- a/.github/azure-devops/pr.yml
+++ b/.github/azure-devops/pr.yml
@@ -13,6 +13,7 @@ pr:
 variables:
   - name: tags
     value: multi-phased
+  - group: PR Metrics
 
 resources:
   repositories:

--- a/.github/azure-devops/template.yml
+++ b/.github/azure-devops/template.yml
@@ -61,7 +61,7 @@ stages:
                   $AccessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
                   tfx login --service-url https://dev.azure.com/$($env:ADOACCOUNT) --token $AccessToken
               env:
-                ADO_ACCOUNT: $(ADOACCOUNT)
+                ADOACCOUNT: $(ADOACCOUNT)
 
             - bash: tfx build tasks delete --task-id 907d3b28-6b37-4ac7-ac75-9631ee53e512 --no-prompt
               displayName: Azure DevOps – Delete Old Task

--- a/.github/azure-devops/template.yml
+++ b/.github/azure-devops/template.yml
@@ -59,9 +59,9 @@ stages:
                 scriptLocation: inlineScript
                 inlineScript: |
                   $AccessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-                  tfx login --service-url https://dev.azure.com/$($env:ADO_ACCOUNT) --token $AccessToken
+                  tfx login --service-url https://dev.azure.com/$($env:ADOACCOUNT) --token $AccessToken
               env:
-                ADO_ACCOUNT: $(ADO_ACCOUNT)
+                ADO_ACCOUNT: $(ADOACCOUNT)
 
             - bash: tfx build tasks delete --task-id 907d3b28-6b37-4ac7-ac75-9631ee53e512 --no-prompt
               displayName: Azure DevOps – Delete Old Task
@@ -94,7 +94,7 @@ stages:
               # Fine-grained Personal Access Token (PAT) with the following permissions for microsoft/PR-Metrics:
               # - Read access to Metadata
               # - Read and Write access to Pull Requests
-              PR_METRICS_ACCESS_TOKEN: $(GITHUB_PAT)
+              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
             inputs:
               file-matching-patterns: |
                 **/*
@@ -125,7 +125,7 @@ stages:
               # Fine-grained Personal Access Token (PAT) with the following permissions for microsoft/PR-Metrics:
               # - Read access to Metadata
               # - Read and Write access to Pull Requests
-              PR_METRICS_ACCESS_TOKEN: $(GITHUB_PAT)
+              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
             inputs:
               file-matching-patterns: |
                 **/*
@@ -156,7 +156,7 @@ stages:
               # Fine-grained Personal Access Token (PAT) with the following permissions for microsoft/PR-Metrics:
               # - Read access to Metadata
               # - Read and Write access to Pull Requests
-              PR_METRICS_ACCESS_TOKEN: $(GITHUB_PAT)
+              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
             inputs:
               file-matching-patterns: |
                 **/*


### PR DESCRIPTION
## Summary

Within the Azure DevOps pipelines, switching from per-pipeline secure variables to secure variables stored within Key Vaults.

This deals with changes to the Azure DevOps configuration files and scripts. The most significant changes include the addition of a `PR Metrics` group to the `variables` in the `pr` sections of `.github/azure-devops/pr-test.yml` and `.github/azure-devops/pr.yml`. In addition, there are several changes to the `stages` section of `.github/azure-devops/template.yml`, including modifications to the `tfx login` command and environment variables, as well as changes to the `PR_METRICS_ACCESS_TOKEN` variable.

Addition of PR Metrics group:

* [`.github/azure-devops/pr-test.yml`](diffhunk://#diff-b21868d02a7dc0e0bc3f3aeabe403c0e5c83e17149e97c3a484f802cf746dff7R16): Added `PR Metrics` group to the `variables` in the `pr` section.
* [`.github/azure-devops/pr.yml`](diffhunk://#diff-4752927e6649128d05329fda79164e4efb31cbb2dc7e6604c99cda9ee03a8b79R16): Added `PR Metrics` group to the `variables` in the `pr` section.

Changes to the `stages` section in `.github/azure-devops/template.yml`:

* Modified the `tfx login` command and changed the `ADO_ACCOUNT` environment variable to `ADOACCOUNT`.
* Replaced the `PR_METRICS_ACCESS_TOKEN` variable from `GITHUB_PAT` to `ADOTOGITHUB` in three instances. [[1]](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L97-R97) [[2]](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L128-R128) [[3]](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L159-R159)

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests