### PR TITLE
XS✔ ◾ Markdown Link Check: Skipping Email Address

### DIFF
--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^https://marketplace.visualstudio.com/manage/publishers/ms-omex$"
+    },
+    {
+      "pattern": "^mailto:"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ can be difficult to determine a value that will work consistently, due to the
 nature of Git history.
 
 To avoid this, it is recommended to only use commit types that squash the Git
-history by using a setting such as
-["require linear history"][github-linear-history].
+history such as "squash merge" or "rebase and fast-forward".
 
 ## Troubleshooting
 
@@ -199,7 +198,6 @@ comments.
 [defaultcodefileextensions]: docs/default-code-file-extensions.md
 [azurepipelinestask]: docs/azure-pipelines-task.md
 [github-token-pemissions]: https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-[github-linear-history]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-linear-history
 [contributing]: .github/CONTRIBUTING.md
 [license]: LICENSE
 [codeofconduct]: https://opensource.microsoft.com/codeofconduct/

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ can be difficult to determine a value that will work consistently, due to the
 nature of Git history.
 
 To avoid this, it is recommended to only use commit types that squash the Git
-history such as "squash merge" or "rebase and fast-forward".
+history by using a setting such as
+["require linear history"][github-linear-history].
 
 ## Troubleshooting
 
@@ -198,6 +199,7 @@ comments.
 [defaultcodefileextensions]: docs/default-code-file-extensions.md
 [azurepipelinestask]: docs/azure-pipelines-task.md
 [github-token-pemissions]: https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+[github-linear-history]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-linear-history
 [contributing]: .github/CONTRIBUTING.md
 [license]: LICENSE
 [codeofconduct]: https://opensource.microsoft.com/codeofconduct/


### PR DESCRIPTION
## Summary

This updates the `.github/linters/markdown-link-check.json` file to add a new exclusion pattern for mailto links. This ensures that the linter does not validate email addresses, where validation will now always fail.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests

### Unit Test Coverage

100%