### PR TITLE
Initial commit

### DIFF
--- a/.github/azure-devops/template.yml
+++ b/.github/azure-devops/template.yml
@@ -22,7 +22,7 @@ stages:
                 delayForMinutes: 5
         ${{ else }}:
           pool:
-            name: Azure-Pipelines-1ESPT-ExDShared
+            name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
             os: linux
             image: ubuntu-latest
           steps:
@@ -69,35 +69,6 @@ stages:
             - bash: tfx build tasks upload --task-path release/task --no-prompt
               displayName: Azure DevOps – Deploy
 
-      - job: PRMetrics_macOS
-        displayName: PR Metrics – macOS
-        dependsOn: Prerequisites
-        pool:
-          ${{ if parameters.testInstance }}:
-            vmImage: macOS-latest
-          ${{ else }}:
-            name: Azure Pipelines
-            os: macOS
-            image: macos-latest
-        variables:
-          - name: System.Debug
-            value: true
-        steps:
-          - checkout: self
-            displayName: Checkout
-            fetchDepth: 0
-
-          - task: PRMetrics@1
-            displayName: PR Metrics
-            env:
-              # Classic Personal Access Token (PAT) with the public_repo scope.
-              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
-            inputs:
-              file-matching-patterns: |
-                **/*
-                !dist/*
-                !package-lock.json
-
       - job: PRMetrics_Ubuntu
         displayName: PR Metrics – Ubuntu
         dependsOn: PRMetrics_macOS
@@ -105,7 +76,7 @@ stages:
           ${{ if parameters.testInstance }}:
             vmImage: ubuntu-latest
           ${{ else }}:
-            name: Azure-Pipelines-1ESPT-ExDShared
+            name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
             os: linux
             image: ubuntu-latest
         variables:
@@ -134,7 +105,7 @@ stages:
           ${{ if parameters.testInstance }}:
             vmImage: windows-latest
           ${{ else }}:
-            name: Azure-Pipelines-1ESPT-ExDShared
+            name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
             os: windows
             image: windows-latest
         variables:

--- a/.github/azure-devops/template.yml
+++ b/.github/azure-devops/template.yml
@@ -71,7 +71,7 @@ stages:
 
       - job: PRMetrics_Ubuntu
         displayName: PR Metrics – Ubuntu
-        dependsOn: PRMetrics_macOS
+        dependsOn: Prerequisites
         pool:
           ${{ if parameters.testInstance }}:
             vmImage: ubuntu-latest


### PR DESCRIPTION
## Summary

This updates the Azure DevOps pipeline configuration to use a static IP pool and removes the `PRMetrics_macOS` job.

### Pipeline configuration updates:

* Updated the pool name from `Azure-Pipelines-1ESPT-ExDShared` to `Azure-Pipelines-1ESPT-ExDShared-StaticIP` for Linux and Windows jobs to ensure the use of a static IP pool. (`.github/azure-devops/template.yml`, [[1]](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L25-R25) [[2]](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L137-R108)

### Job removal:

* Removed the `PRMetrics_macOS` job, including its dependencies, variables, and steps, simplifying the pipeline by focusing on Ubuntu-based metrics collection. (`.github/azure-devops/template.yml`, [.github/azure-devops/template.ymlL72-R79](diffhunk://#diff-9ba73744bad564cb8afb7eac4a1ffce0822431667e90f80de88300f094aae565L72-R79))

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests