### PR TITLE
[WIP] Adding Code Signing

### DIFF
--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -95,12 +95,12 @@ extends:
                 displayName: ESRP CodeSigning
                 inputs:
                   # Signing details are stored within the PR Metrics variable group.
-                  ConnectedServiceName: $(CODESIGNING-CONNECTEDSERVICENAME)
-                  AppRegistrationClientId: $(CODESIGNING-APPREGISTRATIONCLIENTID)
-                  AppRegistrationTenantId: $(CODESIGNING-APPREGISTRATIONTENANTID)
-                  AuthAKVName: $(CODESIGNING-AUTHAKVNAME)
-                  AuthCertName: $(CODESIGNING-AUTHCERTNAME)
-                  AuthSignCertName: $(CODESIGNING-AUTHSIGNCERTNAME)
+                  ConnectedServiceName: $($env:CODESIGNING-CONNECTEDSERVICENAME)
+                  AppRegistrationClientId: $($env:CODESIGNING-APPREGISTRATIONCLIENTID)
+                  AppRegistrationTenantId: $($env:CODESIGNING-APPREGISTRATIONTENANTID)
+                  AuthAKVName: $($env:CODESIGNING-AUTHAKVNAME)
+                  AuthCertName: $($env:CODESIGNING-AUTHCERTNAME)
+                  AuthSignCertName: $($env:CODESIGNING-AUTHSIGNCERTNAME)
                   FolderPath: $(Build.SourcesDirectory)/release
                   Pattern: "*.vsix"
                   signConfigType: inlineSignParams
@@ -122,6 +122,13 @@ extends:
                       }
                     ]
                   SessionTimeout: 30
+                env:
+                  CODESIGNING-CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
+                  CODESIGNING-APPREGISTRATIONCLIENTID: $(CODESIGNING-APPREGISTRATIONCLIENTID)
+                  CODESIGNING-APPREGISTRATIONTENANTID: $(CODESIGNING-APPREGISTRATIONTENANTID)
+                  CODESIGNING-AUTHAKVNAME: $(CODESIGNING-AUTHAKVNAME)
+                  CODESIGNING-AUTHCERTNAME: $(CODESIGNING-AUTHCERTNAME)
+                  CODESIGNING-AUTHSIGNCERTNAME: $(CODESIGNING-AUTHSIGNCERTNAME)
 
               - task: AzureCLI@2
                 displayName: Release – Publish

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -52,10 +52,10 @@ extends:
               - checkout: none
                 displayName: Checkout
 
-              - bash: exit 1
-                displayName: Terminate on Non-Release
-                # Releases are performed on tags, which begin with 'v'.
-                condition: not(startsWith(variables['Build.SourceBranchName'], 'v'))
+              #- bash: exit 1
+              #  displayName: Terminate on Non-Release
+              #  # Releases are performed on tags, which begin with 'v'.
+              #  condition: not(startsWith(variables['Build.SourceBranchName'], 'v'))
 
           - job: Release
             pool:

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,7 +12,6 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
-  - group: PR Metrics
 
 resources:
   repositories:
@@ -59,9 +58,11 @@ extends:
 
           - job: Release
             pool:
-              name: Azure-Pipelines-1ESPT-ExDShared
+              name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
               os: linux
               image: ubuntu-latest
+            variables:
+              - group: PR Metrics
             steps:
               - checkout: self
                 displayName: Checkout
@@ -94,6 +95,7 @@ extends:
               - task: EsrpCodeSigning@5
                 displayName: ESRP CodeSigning
                 inputs:
+                  # Signing details are stored within the PR Metrics variable group.
                   ConnectedServiceName: $(CODESIGNING-CONNECTEDSERVICENAME)
                   AppRegistrationClientId: $(CODESIGNING-APPREGISTRATIONCLIENTID)
                   AppRegistrationTenantId: $(CODESIGNING-APPREGISTRATIONTENANTID)

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -94,12 +94,12 @@ extends:
               - task: EsrpCodeSigning@5
                 displayName: ESRP CodeSigning
                 inputs:
-                  ConnectedServiceName: $env:CONNECTEDSERVICENAME
-                  AppRegistrationClientId: $env:APPREGISTRATIONCLIENTID
-                  AppRegistrationTenantId: $env:APPREGISTRATIONTENANTID
-                  AuthAKVName: $env:AUTHAKVNAME
-                  AuthCertName: $env:AUTHSIGNCERTNAME
-                  AuthSignCertName: $env:AUTHSIGNCERTNAME
+                  ConnectedServiceName: $($env:CONNECTEDSERVICENAME)
+                  AppRegistrationClientId: $($env:APPREGISTRATIONCLIENTID)
+                  AppRegistrationTenantId: $($env:APPREGISTRATIONTENANTID)
+                  AuthAKVName: $($env:AUTHAKVNAME)
+                  AuthCertName: $($env:AUTHSIGNCERTNAME)
+                  AuthSignCertName: $($env:AUTHSIGNCERTNAME)
                   FolderPath: $(Build.SourcesDirectory)/release
                   Pattern: "*.vsix"
                   signConfigType: inlineSignParams

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -97,7 +97,7 @@ extends:
                 displayName: ESRP CodeSigning
                 inputs:
                   # Signing details are stored within the PR Metrics variable group.
-                  ConnectedServiceName: $(CodeSigningConnectedServiceName)
+                  ConnectedServiceName: OmexCodeSigningESRP-Torus
                   AppRegistrationClientId: $(CodeSigningAppRegistrationClientId)
                   AppRegistrationTenantId: $(CodeSigningAppRegistrationTenantId)
                   AuthAKVName: $(CodeSigningAuthAKVName)

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -94,7 +94,7 @@ extends:
               - task: EsrpCodeSigning@5
                 displayName: ESRP CodeSigning
                 inputs:
-                  ConnectedServiceName: $($env:CONNECTEDSERVICENAME)
+                  ConnectedServiceName: $($env:CODESIGNING-CONNECTEDSERVICENAME)
                   AppRegistrationClientId: $($env:APPREGISTRATIONCLIENTID)
                   AppRegistrationTenantId: $($env:APPREGISTRATIONTENANTID)
                   AuthAKVName: $($env:AUTHAKVNAME)
@@ -122,7 +122,7 @@ extends:
                     ]
                   SessionTimeout: 30
                 env:
-                  CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
+                  CODESIGNING-CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
                   APPREGISTRATIONCLIENTID: $(CODESIGNING-APPREGISTRATIONCLIENTID)
                   APPREGISTRATIONTENANTID: $(CODESIGNING-APPREGISTRATIONTENANTID)
                   AUTHAKVNAME: $(CODESIGNING-AUTHAKVNAME)

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -102,6 +102,7 @@ extends:
                   AppRegistrationTenantId: $(CodeSigningAppRegistrationTenantId)
                   AuthAKVName: $(CodeSigningAuthAKVName)
                   AuthSignCertName: $(CodeSigningAuthSignCertName)
+                  UseMSIAuthentication: true
                   FolderPath: $(Build.SourcesDirectory)/release
                   Pattern: "*.vsix"
                   signConfigType: inlineSignParams

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,6 +12,7 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
+  - group: PR Metrics
 
 resources:
   repositories:

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,7 +12,6 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
-  - group: PR Metrics
 
 resources:
   repositories:
@@ -26,7 +25,7 @@ extends:
   parameters:
     sdl:
       sourceAnalysisPool:
-        name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
+        name: Azure-Pipelines-1ESPT-ExDShared
         os: windows
         image: windows-latest
       credscan:
@@ -45,7 +44,7 @@ extends:
         jobs:
           - job: Checks
             pool:
-              name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
+              name: Azure-Pipelines-1ESPT-ExDShared
               os: linux
               image: ubuntu-latest
             steps:

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,6 +12,7 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
+  - group: PR Metrics
 
 resources:
   repositories:
@@ -25,7 +26,7 @@ extends:
   parameters:
     sdl:
       sourceAnalysisPool:
-        name: Azure-Pipelines-1ESPT-ExDShared
+        name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
         os: windows
         image: windows-latest
       credscan:
@@ -44,7 +45,7 @@ extends:
         jobs:
           - job: Checks
             pool:
-              name: Azure-Pipelines-1ESPT-ExDShared
+              name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
               os: linux
               image: ubuntu-latest
             steps:
@@ -61,8 +62,6 @@ extends:
               name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
               os: linux
               image: ubuntu-latest
-            variables:
-              - group: PR Metrics
             steps:
               - checkout: self
                 displayName: Checkout

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,7 +12,6 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
-  - group: PR Metrics
 
 resources:
   repositories:
@@ -62,6 +61,8 @@ extends:
               name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
               os: linux
               image: ubuntu-latest
+            variables:
+              - group: PR Metrics
             steps:
               - checkout: self
                 displayName: Checkout

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -12,6 +12,7 @@ pr: none
 variables:
   - name: tags
     value: production, multi-phased
+  - group: PR Metrics
 
 resources:
   repositories:
@@ -89,6 +90,44 @@ extends:
               - bash: tfx extension create --manifest-globs vss-extension.json --output-path ../ms-omex.PRMetrics.vsix
                 displayName: Release – Create
                 workingDirectory: $(Build.SourcesDirectory)/release
+
+              - task: EsrpCodeSigning@5
+                displayName: ESRP CodeSigning
+                inputs:
+                  ConnectedServiceName: $env:CONNECTEDSERVICENAME
+                  AppRegistrationClientId: $env:APPREGISTRATIONCLIENTID
+                  AppRegistrationTenantId: $env:APPREGISTRATIONTENANTID
+                  AuthAKVName: $env:AUTHAKVNAME
+                  AuthCertName: $env:AUTHSIGNCERTNAME
+                  AuthSignCertName: $env:AUTHSIGNCERTNAME
+                  FolderPath: $(Build.SourcesDirectory)/release
+                  Pattern: "*.vsix"
+                  signConfigType: inlineSignParams
+                  inlineOperation: |-
+                    [
+                      {
+                        "KeyCode": "CP-500813",
+                        "OperationCode": "AdoExtensionSign",
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0",
+                        "Parameters": {}
+                      },
+                      {
+                        "KeyCode": "CP-500813",
+                        "OperationCode": "AdoExtensionVerify",
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0",
+                        "Parameters": {}
+                      }
+                    ]
+                  SessionTimeout: 30
+                env:
+                  CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
+                  APPREGISTRATIONCLIENTID: $(CODESIGNING-APPREGISTRATIONCLIENTID)
+                  APPREGISTRATIONTENANTID: $(CODESIGNING-APPREGISTRATIONTENANTID)
+                  AUTHAKVNAME: $(CODESIGNING-AUTHAKVNAME)
+                  AUTHCERTNAME: $(CODESIGNING-AUTHCERTNAME)
+                  AUTHSIGNCERTNAME: $(CODESIGNING-AUTHSIGNCERTNAME)
 
               - task: AzureCLI@2
                 displayName: Release – Publish

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -96,12 +96,11 @@ extends:
                 displayName: ESRP CodeSigning
                 inputs:
                   # Signing details are stored within the PR Metrics variable group.
-                  ConnectedServiceName: $($env:CODESIGNING-CONNECTEDSERVICENAME)
-                  AppRegistrationClientId: $($env:CODESIGNING-APPREGISTRATIONCLIENTID)
-                  AppRegistrationTenantId: $($env:CODESIGNING-APPREGISTRATIONTENANTID)
-                  AuthAKVName: $($env:CODESIGNING-AUTHAKVNAME)
-                  AuthCertName: $($env:CODESIGNING-AUTHCERTNAME)
-                  AuthSignCertName: $($env:CODESIGNING-AUTHSIGNCERTNAME)
+                  ConnectedServiceName: $(CodeSigningConnectedServiceName)
+                  AppRegistrationClientId: $(CodeSigningAppRegistrationClientId)
+                  AppRegistrationTenantId: $(CodeSigningAppRegistrationTenantId)
+                  AuthAKVName: $(CodeSigningAuthAKVName)
+                  AuthSignCertName: $(CodeSigningAuthSignCertName)
                   FolderPath: $(Build.SourcesDirectory)/release
                   Pattern: "*.vsix"
                   signConfigType: inlineSignParams
@@ -123,16 +122,16 @@ extends:
                       }
                     ]
                   SessionTimeout: 30
-                env:
-                  CODESIGNING-CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
-                  CODESIGNING-APPREGISTRATIONCLIENTID: $(CODESIGNING-APPREGISTRATIONCLIENTID)
-                  CODESIGNING-APPREGISTRATIONTENANTID: $(CODESIGNING-APPREGISTRATIONTENANTID)
-                  CODESIGNING-AUTHAKVNAME: $(CODESIGNING-AUTHAKVNAME)
-                  CODESIGNING-AUTHCERTNAME: $(CODESIGNING-AUTHCERTNAME)
-                  CODESIGNING-AUTHSIGNCERTNAME: $(CODESIGNING-AUTHSIGNCERTNAME)
 
               - task: AzureCLI@2
                 displayName: Release – Publish
+                inputs:
+                  azureSubscription: PR Metrics
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    $AccessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+                    tfx extension publish --service-url https://marketplace.visualstudio.com/ --token $AccessToken --vsix ms-omex.PRMetrics.vsix
                 inputs:
                   azureSubscription: PR Metrics
                   scriptType: pscore

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -94,12 +94,12 @@ extends:
               - task: EsrpCodeSigning@5
                 displayName: ESRP CodeSigning
                 inputs:
-                  ConnectedServiceName: $($env:CODESIGNING-CONNECTEDSERVICENAME)
-                  AppRegistrationClientId: $($env:APPREGISTRATIONCLIENTID)
-                  AppRegistrationTenantId: $($env:APPREGISTRATIONTENANTID)
-                  AuthAKVName: $($env:AUTHAKVNAME)
-                  AuthCertName: $($env:AUTHSIGNCERTNAME)
-                  AuthSignCertName: $($env:AUTHSIGNCERTNAME)
+                  ConnectedServiceName: $(CODESIGNING-CONNECTEDSERVICENAME)
+                  AppRegistrationClientId: $(CODESIGNING-APPREGISTRATIONCLIENTID)
+                  AppRegistrationTenantId: $(CODESIGNING-APPREGISTRATIONTENANTID)
+                  AuthAKVName: $(CODESIGNING-AUTHAKVNAME)
+                  AuthCertName: $(CODESIGNING-AUTHCERTNAME)
+                  AuthSignCertName: $(CODESIGNING-AUTHSIGNCERTNAME)
                   FolderPath: $(Build.SourcesDirectory)/release
                   Pattern: "*.vsix"
                   signConfigType: inlineSignParams
@@ -121,13 +121,6 @@ extends:
                       }
                     ]
                   SessionTimeout: 30
-                env:
-                  CODESIGNING-CONNECTEDSERVICENAME: $(CODESIGNING-CONNECTEDSERVICENAME)
-                  APPREGISTRATIONCLIENTID: $(CODESIGNING-APPREGISTRATIONCLIENTID)
-                  APPREGISTRATIONTENANTID: $(CODESIGNING-APPREGISTRATIONTENANTID)
-                  AUTHAKVNAME: $(CODESIGNING-AUTHAKVNAME)
-                  AUTHCERTNAME: $(CODESIGNING-AUTHCERTNAME)
-                  AUTHSIGNCERTNAME: $(CODESIGNING-AUTHSIGNCERTNAME)
 
               - task: AzureCLI@2
                 displayName: Release – Publish

--- a/.github/azure-devops/release.yml
+++ b/.github/azure-devops/release.yml
@@ -132,10 +132,3 @@ extends:
                   inlineScript: |
                     $AccessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
                     tfx extension publish --service-url https://marketplace.visualstudio.com/ --token $AccessToken --vsix ms-omex.PRMetrics.vsix
-                inputs:
-                  azureSubscription: PR Metrics
-                  scriptType: pscore
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    $AccessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-                    tfx extension publish --service-url https://marketplace.visualstudio.com/ --token $AccessToken --vsix ms-omex.PRMetrics.vsix


### PR DESCRIPTION
## Summary

This change makes updates to the Azure DevOps release pipeline configuration file (`.github/azure-devops/release.yml`) to improve release management and add code signing functionality. The most important changes include commenting out a termination step for non-release builds, updating the agent pool name, adding a variable group, and introducing ESRP CodeSigning to sign and verify release artifacts.

### Updates to release pipeline configuration:

* **Updated agent pool name:** The agent pool name for the `Release` job has been changed from `Azure-Pipelines-1ESPT-ExDShared` to `Azure-Pipelines-1ESPT-ExDShared-StaticIP` to use a pool with static IP capabilities.

* **Added variable group:** A new variable group named `PR Metrics` has been added to the `Release` job to manage pipeline variables more effectively.

* **Introduced ESRP CodeSigning task:** A new task, `EsrpCodeSigning@5`, has been added to sign and verify `.vsix` release artifacts using ESRP CodeSigning. This includes specifying authentication details, signing parameters, and a session timeout.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests