### PR TITLE
XS✔ ◾ Enhancing AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,8 @@ npm run test:fast      # Quick test run during development
 - **Production**: `src/task/src/` - Main source code
 - **Tests**: `src/task/tests/` - Mirror source structure for test files
 - **Interfaces**: Separate `.d.ts` files for all major interfaces
-- **Build Outputs**: `debug/`, `release/`, `dist/` (git-ignored)
+- **Build Outputs**: `debug/`, `release/` (git-ignored), `dist/` (committed for
+  GitHub Action)
 
 ### Critical Git Command
 
@@ -111,10 +112,9 @@ The core functionality relies on:
 ### Environment Variables
 
 `PR_METRICS_ACCESS_TOKEN` - The only token variable read by the source code.
-Typically set to `${{ secrets.GITHUB_TOKEN }}` in workflows (requires
-`pull-requests: write`, `statuses: write` permissions) or to an Azure DevOps
-PAT. Can also be populated automatically by workload identity federation via
-`TokenManager`.
+Typically set to `${{ secrets.GITHUB_TOKEN }}` in workflows or to an Azure
+DevOps PAT. Can also be populated automatically by workload identity federation
+via `TokenManager`.
 
 ### External APIs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ npm run test:fast      # Quick test run during development
 - **Production**: `src/task/src/` - Main source code
 - **Tests**: `src/task/tests/` - Mirror source structure for test files
 - **Interfaces**: Separate `.d.ts` files for all major interfaces
-- **Build Outputs**: `debug/`, `release/`, `dist/` (git-ignored)
+- **Build Outputs**: `debug/`, `release/` (git-ignored), `dist/` (committed for
+  GitHub Action)
 
 ### Critical Git Command
 
@@ -111,10 +112,9 @@ The core functionality relies on:
 ### Environment Variables
 
 `PR_METRICS_ACCESS_TOKEN` - The only token variable read by the source code.
-Typically set to `${{ secrets.GITHUB_TOKEN }}` in workflows (requires
-`pull-requests: write`, `statuses: write` permissions) or to an Azure DevOps
-PAT. Can also be populated automatically by workload identity federation via
-`TokenManager`.
+Typically set to `${{ secrets.GITHUB_TOKEN }}` in workflows or to an Azure
+DevOps PAT. Can also be populated automatically by workload identity federation
+via `TokenManager`.
 
 ### External APIs
 


### PR DESCRIPTION
## Summary

This updates the `AGENTS.md` documentation to clarify architectural patterns, testing strategies, linting, and environment variable usage. The changes emphasize the codebase's dual-platform support, improved error handling, enhanced testing practices, and more explicit configuration guidance.

**Architecture and Core Patterns:**

* Clarified that `reposInvoker.ts` routes to either `gitHubReposInvoker.ts` or `azureReposInvoker.ts`, both of which now extend `baseReposInvoker.ts` for shared API error handling (including mapping 401/403/404 errors to access-error messages). Added mention of `tokenManager.ts` for workload identity federation as an alternative to Personal Access Tokens.
* Expanded on the main workflow orchestration: `pullRequestMetrics.ts` now explicitly calls `codeMetricsCalculator.updateDetails()` and `codeMetricsCalculator.updateComments()` in parallel. Documented that `codeMetricsCalculator.ts` defines these methods.
* Added a new section for diff parsing: `octokitGitDiffParser.ts` uses the `parse-git-diff` library to determine the first changed line per file for precise comment placement on GitHub PRs.

**Linting and TypeScript Conventions:**

* Updated linting instructions to clarify that `npm run lint` now uses ESLint with autofix. Expanded details on ESLint configuration: uses flat config (`eslint.config.mjs`) extending `strictTypeChecked` and `stylisticTypeChecked` presets, with extensive custom rules. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L54-R63) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L74-R85)

**Testing Patterns:**

* Enhanced testing documentation to include the use of `fast-check` for property-based testing. Clarified that `.property.spec.ts` files are for property-based (fuzz) tests, in addition to `.spec.ts` files mirroring the source structure.

**Environment Variables:**

* Simplified and clarified environment variable usage: `PR_METRICS_ACCESS_TOKEN` is now the only token variable read by the source code, typically set to `${{ secrets.GITHUB_TOKEN }}` or an Azure DevOps PAT, and can also be populated by workload identity federation via `TokenManager`.