### PR TITLE
XS⚠️ ◾ Correct version number handling in release workflow

### DIFF
--- a/.github/workflows/release-initiate.yml
+++ b/.github/workflows/release-initiate.yml
@@ -12,8 +12,8 @@ permissions: {}
 # The version below is the upcoming release version, not the current one.
 env:
   major: 1
-  minor: 2
-  patch: 0
+  minor: 7
+  patch: 12
 
 defaults:
   run:
@@ -95,10 +95,10 @@ jobs:
         run: npm install
 
       - name: npm – Update Dependencies
-        run: npm run update:versions
+        run: npx ncu -u
 
       - name: npm – Update Transitive Dependencies
-        run: npm run update:dependencies
+        run: npm update
 
       - name: Git – Commit & Push (Signed)
         uses: grafana/github-api-commit-action@cb4e7799d2cd77d607acf280ed70a0d03572d8bd # v1.0.0

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "deploy": "npm run build:release && exitzero tfx build tasks delete --task-id 907d3b28-6b37-4ac7-ac75-9631ee53e512 --no-prompt && tfx build tasks upload --task-path release/task --no-prompt",
     "lint": "eslint --fix **/*.ts",
     "test": "npm run build:debug && cd debug/task && c8 --reporter=text --reporter=text-summary mocha tests/**/*.spec.js",
-    "test:fast": "mkdirp debug && ncp src debug && cd debug/task && tsc --sourceMap && c8 --reporter=text --reporter=text-summary mocha tests/**/*.spec.js",
-    "update:dependencies": "npm update",
-    "update:versions": "ncu -u"
+    "test:fast": "mkdirp debug && ncp src debug && cd debug/task && tsc --sourceMap && c8 --reporter=text --reporter=text-summary mocha tests/**/*.spec.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- The `env` vars in `release-initiate.yml` now represent the actual release version instead of requiring a runtime patch+1 computation. The increment logic for the _next_ release is moved into `Update-Version.ps1`.
- Inline `npx ncu -u` and `npm update` commands replaced with `npm run update:versions` and `npm run update:dependencies` scripts for guarantees around tool versions.

## Testing

### Test Types

- [ ] Unit tests
- [X] Manual tests