### PR TITLE
XS✔ ◾ Pin npm dependency installation

### DIFF
--- a/.github/workflows/release-initiate.yml
+++ b/.github/workflows/release-initiate.yml
@@ -91,7 +91,7 @@ jobs:
           node-version: 20.17.0
 
       - name: npm – Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: npm – Update Package Versions
         run: npm run update:versions


### PR DESCRIPTION
## Summary

- Replaces `npm install` with `npm ci` in the release initiation workflow to satisfy the OpenSSF Scorecard pinned-dependencies check.
- Improves supply chain security by ensuring dependencies are installed from the lockfile.
- No functional impact – subsequent update scripts still run as before.