### PR TITLE
XS⚠️ ◾ Authenticate pipeline with GitHub App

### DIFF
--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -162,7 +162,11 @@ if ($null -eq $installation.id)
     throw "Could not determine the App installation for '$repository'."
 }
 
-$accessToken = Invoke-GitHubApi -Uri "$apiUrl/app/installations/$($installation.id)/access_tokens" -Jwt $jwt -Method 'Post' -Body @{ permissions = @{ pull_requests = 'write' } }
+$body = @{
+    repositories = @(($repository -split '/')[1])
+    permissions  = @{ pull_requests = 'write' }
+}
+$accessToken = Invoke-GitHubApi -Uri "$apiUrl/app/installations/$($installation.id)/access_tokens" -Jwt $jwt -Method 'Post' -Body $body
 if ([string]::IsNullOrWhiteSpace($accessToken.token))
 {
     throw 'The GitHub App installation token could not be minted.'

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -44,7 +44,13 @@ function Get-DecodedPem
     }
     catch
     {
-        throw 'The GITHUB_APP_PRIVATE_KEY secret is not valid Base64. Store the Base64 encoding of the App private key PEM file.'
+        # Report non-sensitive shape details (never the key) to pinpoint the cause.
+        $shape = "rawLength=$($Value.Length)" +
+            ", strippedLength=$($candidate.Length)" +
+            ", lengthMod4=$($candidate.Length % 4)" +
+            ", nonBase64Chars=$(([regex]::Matches($candidate, '[^A-Za-z0-9+/=]')).Count)" +
+            ", looksLikePem=$([bool]($Value -match '-----BEGIN '))"
+        throw "The GITHUB_APP_PRIVATE_KEY secret is not valid Base64. Store the Base64 encoding of the App private key PEM file. Diagnostics: $shape"
     }
 
     return [System.Text.Encoding]::UTF8.GetString($bytes)

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -25,7 +25,7 @@ function ConvertTo-Base64Url
     return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
-function New-JsonWebToken
+function Get-JsonWebToken
 {
     param
     (
@@ -121,7 +121,7 @@ if ([string]::IsNullOrWhiteSpace($privateKey))
     throw "The 'GITHUB_APP_PRIVATE_KEY' environment variable is not set."
 }
 
-$jwt = New-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
+$jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
 
 $installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
 if ($null -eq $installation.id)
@@ -137,5 +137,5 @@ if ([string]::IsNullOrWhiteSpace($accessToken.token))
 
 # Register the token as a secret so it is masked in the logs, then expose it to
 # the subsequent PR Metrics step via the output variable.
-Write-Host "##vso[task.setvariable variable=$outputVariable;issecret=true]$($accessToken.token)"
-Write-Host "Minted an installation token for '$repository' (installation $($installation.id))."
+Write-Output -InputObject "##vso[task.setvariable variable=$outputVariable;issecret=true]$($accessToken.token)"
+Write-Output -InputObject "Minted an installation token for '$repository' (installation $($installation.id))."

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -25,6 +25,33 @@ function ConvertTo-Base64Url
     return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
+function Get-NormalizedPem
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $Value
+    )
+
+    # A Key Vault secret consumed through an Azure DevOps variable group often
+    # loses its line breaks, so rebuild the PEM envelope with correctly wrapped
+    # Base64. This tolerates real, escaped, spaced, or stripped newlines.
+    $text = $Value -replace '\\r', '' -replace '\\n', "`n"
+    $match = [regex]::Match(
+        $text,
+        '-----BEGIN (?<label>[A-Z0-9 ]+?)-----(?<body>.*?)-----END \k<label>-----',
+        [System.Text.RegularExpressions.RegexOptions]::Singleline)
+    if (-not $match.Success)
+    {
+        return $text
+    }
+
+    $label = $match.Groups['label'].Value.Trim()
+    $body = $match.Groups['body'].Value -replace '[^A-Za-z0-9+/=]', ''
+    $wrapped = [regex]::Replace($body, '.{1,64}', "`$0`n").TrimEnd("`n")
+    return "-----BEGIN $label-----`n$wrapped`n-----END $label-----`n"
+}
+
 function Get-JsonWebToken
 {
     param
@@ -53,8 +80,7 @@ function Get-JsonWebToken
     $rsa = [System.Security.Cryptography.RSA]::Create()
     try
     {
-        # Normalize keys that arrive with escaped newlines from the secret store.
-        $rsa.ImportFromPem(($PrivateKey -replace '\\n', "`n"))
+        $rsa.ImportFromPem((Get-NormalizedPem -Value $PrivateKey))
         $signature = $rsa.SignData(
             [System.Text.Encoding]::ASCII.GetBytes($signingInput),
             [System.Security.Cryptography.HashAlgorithmName]::SHA256,

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -1,0 +1,141 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Mints a short-lived 'pr-metrics-access-app' installation token, scoped to
+# 'Pull requests: write', and publishes it to the job as a secret variable so PR
+# Metrics can update the originating GitHub pull request. Only the private key is
+# a secret, read from the GITHUB_APP_PRIVATE_KEY environment variable; the App's
+# client ID, repository, and endpoints are fixed below.
+
+$ErrorActionPreference = 'Stop'
+
+$clientId = 'Iv23lilx6AekMDUze7ss'
+$repository = 'microsoft/PR-Metrics'
+$apiUrl = 'https://api.github.com'
+$outputVariable = 'GitHubAppToken'
+
+function ConvertTo-Base64Url
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [byte[]] $Bytes
+    )
+
+    return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function New-JsonWebToken
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $ClientId,
+        [Parameter(Mandatory = $true)]
+        [string] $PrivateKey
+    )
+
+    $issuedAt = [System.DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $header = [ordered] @{
+        alg = 'RS256'
+        typ = 'JWT'
+    }
+    $payload = [ordered] @{
+        exp = $issuedAt + 540
+        iat = $issuedAt - 60
+        iss = $ClientId
+    }
+
+    $headerEncoded = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress)))
+    $payloadEncoded = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+    $signingInput = "$headerEncoded.$payloadEncoded"
+
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try
+    {
+        # Normalize keys that arrive with escaped newlines from the secret store.
+        $rsa.ImportFromPem(($PrivateKey -replace '\\n', "`n"))
+        $signature = $rsa.SignData(
+            [System.Text.Encoding]::ASCII.GetBytes($signingInput),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    }
+    finally
+    {
+        $rsa.Dispose()
+    }
+
+    return "$signingInput.$(ConvertTo-Base64Url -Bytes $signature)"
+}
+
+function Invoke-GitHubApi
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $Uri,
+        [Parameter(Mandatory = $true)]
+        [string] $Jwt,
+        [Parameter(Mandatory = $true)]
+        [string] $Method,
+        [Parameter(Mandatory = $false)]
+        [object] $Body
+    )
+
+    $parameters = @{
+        Uri       = $Uri
+        Method    = $Method
+        UserAgent = 'PR-Metrics'
+        Headers   = @{
+            Accept                 = 'application/vnd.github+json'
+            Authorization          = "Bearer $Jwt"
+            'X-GitHub-Api-Version' = '2022-11-28'
+        }
+    }
+    if ($null -ne $Body)
+    {
+        $parameters.Body = $Body | ConvertTo-Json -Compress -Depth 10
+        $parameters.ContentType = 'application/json'
+    }
+
+    try
+    {
+        return Invoke-RestMethod @parameters
+    }
+    catch
+    {
+        # The error body never contains the token, so it is safe to surface.
+        $detail = $_.ErrorDetails.Message
+        if ([string]::IsNullOrWhiteSpace($detail))
+        {
+            $detail = $_.Exception.Message
+        }
+
+        throw "GitHub API request to '$Uri' failed: $detail"
+    }
+}
+
+$privateKey = [System.Environment]::GetEnvironmentVariable('GITHUB_APP_PRIVATE_KEY')
+if ([string]::IsNullOrWhiteSpace($privateKey))
+{
+    throw "The 'GITHUB_APP_PRIVATE_KEY' environment variable is not set."
+}
+
+$jwt = New-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
+
+$installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
+if ($null -eq $installation.id)
+{
+    throw "Could not determine the App installation for '$repository'."
+}
+
+$accessToken = Invoke-GitHubApi -Uri "$apiUrl/app/installations/$($installation.id)/access_tokens" -Jwt $jwt -Method 'Post' -Body @{ permissions = @{ pull_requests = 'write' } }
+if ([string]::IsNullOrWhiteSpace($accessToken.token))
+{
+    throw 'The GitHub App installation token could not be minted.'
+}
+
+# Register the token as a secret so it is masked in the logs, then expose it to
+# the subsequent PR Metrics step via the output variable.
+Write-Host "##vso[task.setvariable variable=$outputVariable;issecret=true]$($accessToken.token)"
+Write-Host "Minted an installation token for '$repository' (installation $($installation.id))."

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -27,19 +27,6 @@ function ConvertTo-Base64Url
     return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
-function ConvertFrom-Base64Url
-{
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [string] $Text
-    )
-
-    $base64 = $Text.Replace('-', '+').Replace('_', '/')
-    $base64 = $base64.PadRight([int][System.Math]::Ceiling($base64.Length / 4.0) * 4, '=')
-    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64))
-}
-
 function Get-DecodedPem
 {
     param
@@ -57,13 +44,7 @@ function Get-DecodedPem
     }
     catch
     {
-        # Report non-sensitive shape details (never the key) to pinpoint the cause.
-        $shape = "rawLength=$($Value.Length)" +
-            ", strippedLength=$($candidate.Length)" +
-            ", lengthMod4=$($candidate.Length % 4)" +
-            ", nonBase64Chars=$(([regex]::Matches($candidate, '[^A-Za-z0-9+/=]')).Count)" +
-            ", looksLikePem=$([bool]($Value -match '-----BEGIN '))"
-        throw "The GITHUB_APP_PRIVATE_KEY secret is not valid Base64. Store the Base64 encoding of the App private key PEM file. Diagnostics: $shape"
+        throw 'The GITHUB_APP_PRIVATE_KEY secret is not valid Base64. Store the Base64 encoding of the App private key PEM file.'
     }
 
     return [System.Text.Encoding]::UTF8.GetString($bytes)
@@ -175,19 +156,7 @@ if ([string]::IsNullOrWhiteSpace($privateKey))
 
 $jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
 
-try
-{
-    $installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
-}
-catch
-{
-    # The JWT header and payload are not secret; decode them to confirm the
-    # token's shape and claims (alg, iss, iat, exp) when GitHub rejects it.
-    $segments = $jwt.Split('.')
-    $claims = ($segments | Select-Object -First 2 | ForEach-Object { ConvertFrom-Base64Url -Text $_ }) -join ' '
-    throw "$($_.Exception.Message) [JWT segments=$($segments.Count); claims=$claims]"
-}
-
+$installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
 if ($null -eq $installation.id)
 {
     throw "Could not determine the App installation for '$repository'."

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -4,8 +4,10 @@
 # Mints a short-lived 'pr-metrics-access-app' installation token, scoped to
 # 'Pull requests: write', and publishes it to the job as a secret variable so PR
 # Metrics can update the originating GitHub pull request. Only the private key is
-# a secret, read from the GITHUB_APP_PRIVATE_KEY environment variable; the App's
-# client ID, repository, and endpoints are fixed below.
+# a secret, read from the GITHUB_APP_PRIVATE_KEY environment variable as the
+# Base64 encoding of the PEM file. Base64 keeps the key on a single line so the
+# variable group cannot mangle its line breaks. The App's client ID, repository,
+# and endpoints are fixed below.
 
 $ErrorActionPreference = 'Stop'
 
@@ -25,7 +27,7 @@ function ConvertTo-Base64Url
     return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
-function Get-NormalizedPem
+function Get-DecodedPem
 {
     param
     (
@@ -33,23 +35,19 @@ function Get-NormalizedPem
         [string] $Value
     )
 
-    # A Key Vault secret consumed through an Azure DevOps variable group often
-    # loses its line breaks, so rebuild the PEM envelope with correctly wrapped
-    # Base64. This tolerates real, escaped, spaced, or stripped newlines.
-    $text = $Value -replace '\\r', '' -replace '\\n', "`n"
-    $match = [regex]::Match(
-        $text,
-        '-----BEGIN (?<label>[A-Z0-9 ]+?)-----(?<body>.*?)-----END \k<label>-----',
-        [System.Text.RegularExpressions.RegexOptions]::Singleline)
-    if (-not $match.Success)
+    # The secret holds the PEM file Base64-encoded, which keeps it on a single
+    # line so the variable group cannot mangle its line breaks.
+    $candidate = $Value -replace '\s', ''
+    try
     {
-        return $text
+        $bytes = [System.Convert]::FromBase64String($candidate)
+    }
+    catch
+    {
+        throw 'The GITHUB_APP_PRIVATE_KEY secret is not valid Base64. Store the Base64 encoding of the App private key PEM file.'
     }
 
-    $label = $match.Groups['label'].Value.Trim()
-    $body = $match.Groups['body'].Value -replace '[^A-Za-z0-9+/=]', ''
-    $wrapped = [regex]::Replace($body, '.{1,64}', "`$0`n").TrimEnd("`n")
-    return "-----BEGIN $label-----`n$wrapped`n-----END $label-----`n"
+    return [System.Text.Encoding]::UTF8.GetString($bytes)
 }
 
 function Get-JsonWebToken
@@ -80,7 +78,16 @@ function Get-JsonWebToken
     $rsa = [System.Security.Cryptography.RSA]::Create()
     try
     {
-        $rsa.ImportFromPem((Get-NormalizedPem -Value $PrivateKey))
+        $pem = Get-DecodedPem -Value $PrivateKey
+        try
+        {
+            $rsa.ImportFromPem($pem)
+        }
+        catch
+        {
+            throw "The decoded GITHUB_APP_PRIVATE_KEY is not a valid PEM key: $($_.Exception.Message)"
+        }
+
         $signature = $rsa.SignData(
             [System.Text.Encoding]::ASCII.GetBytes($signingInput),
             [System.Security.Cryptography.HashAlgorithmName]::SHA256,

--- a/.github/azure-devops/scripts/New-GitHubAppToken.ps1
+++ b/.github/azure-devops/scripts/New-GitHubAppToken.ps1
@@ -27,6 +27,19 @@ function ConvertTo-Base64Url
     return [System.Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
+function ConvertFrom-Base64Url
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string] $Text
+    )
+
+    $base64 = $Text.Replace('-', '+').Replace('_', '/')
+    $base64 = $base64.PadRight([int][System.Math]::Ceiling($base64.Length / 4.0) * 4, '=')
+    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64))
+}
+
 function Get-DecodedPem
 {
     param
@@ -162,7 +175,19 @@ if ([string]::IsNullOrWhiteSpace($privateKey))
 
 $jwt = Get-JsonWebToken -ClientId $clientId -PrivateKey $privateKey
 
-$installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
+try
+{
+    $installation = Invoke-GitHubApi -Uri "$apiUrl/repos/$repository/installation" -Jwt $jwt -Method 'Get'
+}
+catch
+{
+    # The JWT header and payload are not secret; decode them to confirm the
+    # token's shape and claims (alg, iss, iat, exp) when GitHub rejects it.
+    $segments = $jwt.Split('.')
+    $claims = ($segments | Select-Object -First 2 | ForEach-Object { ConvertFrom-Base64Url -Text $_ }) -join ' '
+    throw "$($_.Exception.Message) [JWT segments=$($segments.Count); claims=$claims]"
+}
+
 if ($null -eq $installation.id)
 {
     throw "Could not determine the App installation for '$repository'."

--- a/.github/azure-devops/template.yml
+++ b/.github/azure-devops/template.yml
@@ -82,11 +82,18 @@ stages:
             displayName: Checkout
             fetchDepth: 0
 
+          - task: PowerShell@2
+            displayName: App Token – Mint
+            inputs:
+              pwsh: true
+              filePath: .github/azure-devops/scripts/New-GitHubAppToken.ps1
+            env:
+              GITHUB_APP_PRIVATE_KEY: $(private-key)
+
           - task: PRMetrics@1
             displayName: PR Metrics
             env:
-              # Classic Personal Access Token (PAT) with the public_repo scope.
-              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
+              PR_METRICS_ACCESS_TOKEN: $(GitHubAppToken)
             inputs:
               file-matching-patterns: |
                 **/*
@@ -109,11 +116,18 @@ stages:
             displayName: Checkout
             fetchDepth: 0
 
+          - task: PowerShell@2
+            displayName: App Token – Mint
+            inputs:
+              pwsh: true
+              filePath: .github/azure-devops/scripts/New-GitHubAppToken.ps1
+            env:
+              GITHUB_APP_PRIVATE_KEY: $(private-key)
+
           - task: PRMetrics@1
             displayName: PR Metrics
             env:
-              # Classic Personal Access Token (PAT) with the public_repo scope.
-              PR_METRICS_ACCESS_TOKEN: $(ADOTOGITHUB)
+              PR_METRICS_ACCESS_TOKEN: $(GitHubAppToken)
             inputs:
               file-matching-patterns: |
                 **/*

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -19,10 +19,14 @@ pipelines.
   token through gh-aw's native `github-app:` block.
 - **`PRIVATE_KEY`**: GitHub Actions secret holding the App's RSA private key.
   Every workflow that needs the App installation token reads this secret via
-  `actions/create-github-app-token`.
+  `actions/create-github-app-token`. A GitHub App key is also surfaced through
+  the `PR Metrics` Azure DevOps variable group, so the Azure DevOps test
+  pipeline can mint its own installation token with the script at
+  `.github/azure-devops/scripts/New-GitHubAppToken.ps1`.
 - **`PR_METRICS_ACCESS_TOKEN`**: Access token passed to the PR Metrics action.
   Environment variable scoped to the workflow/job run; populated with the
-  short-lived App installation token described above.
+  short-lived App installation token described above, in both GitHub Actions and
+  the Azure DevOps test pipeline.
 - **ESRP service connection**: Code signing for Azure DevOps marketplace
   releases. Azure DevOps pipeline-scoped.
 
@@ -61,8 +65,8 @@ control. The `.gitignore` file excludes common environment file patterns
 - **App installation tokens**: Minted per job with a one-hour lifetime and
   discarded at job end. No standing token exists to rotate.
 - **`PRIVATE_KEY`**: The App's RSA private key. Rotate by generating a new key
-  for the App and updating the GitHub Actions secret, with a recommended cadence
-  of annually or on suspected compromise.
+  for the App and updating both the GitHub Actions secret and the key vault
+  secret, with a recommended cadence of annually or on suspected compromise.
 - **ESRP Credentials**: Managed by the Microsoft ESRP service and rotated
   according to Microsoft's internal policies.
 


### PR DESCRIPTION
## Purpose

The test pipeline comments on and updates the originating GitHub pull request as
it validates changes. It previously authenticated with a long-lived classic
Personal Access Token, which now requires frequent rotation and relies on a
shared bot account.

## Impact

The pipeline now authenticates with the same GitHub App already used by the
GitHub Actions workflows. A short-lived installation token is minted for each
job and expires after one hour, so there is no standing credential and no bot
account to maintain. The App's private key is the only secret involved, supplied
through the existing pipeline secret store, and the token is scoped to the
minimum permission required to update pull requests.

Pull request comments will now originate from the GitHub App rather than the bot
account, matching the GitHub Actions behaviour.

Before merge, the App's private key must be added to the pipeline secret store,
or the test pipeline cannot authenticate.