### PR TITLE
XS✔ ◾ Fix Dependabot auto-merge permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
           azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          permissions: '{"pull_requests":"write"}'
+          permissions: '{"contents":"write","pull_requests":"write","workflows":"write"}'
 
       - if: github.event.pull_request.user.login == 'dependabot[bot]'
         name: Enable Auto-Merge


### PR DESCRIPTION
## Purpose

Auto-merge for Dependabot pull requests regressed after GitHub App tokens were scoped to least privilege per job. The token that enables auto-merge no longer carried the access needed to schedule a merge or to update workflow files, so it failed with a permissions error.

## Impact

Dependabot pull requests can be auto-merged again. Every Dependabot update in this repository targets GitHub Actions and therefore modifies workflow files, so the auto-merge token now also requests the corresponding access. This relies on the matching Workflows permission being granted on the GitHub App installation.