### PR TITLE
XS⚠️ ◾ Enable PowerShell strict mode

### DIFF
--- a/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
+++ b/.github/actions/mint-github-app-token/New-GitHubAppToken.ps1
@@ -10,6 +10,7 @@
 # must hold 'Key Vault Crypto User' on the vault. Configuration is read from the
 # environment, and the token is published in the form the host CI understands.
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $apiUrl = 'https://api.github.com'

--- a/.github/workflow-scripts/Test-Changes.ps1
+++ b/.github/workflow-scripts/Test-Changes.ps1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+Set-StrictMode -Version Latest
+
 $gitStatus = git status --porcelain
 Write-Output -InputObject $gitStatus
 $changesPresent = [bool]$gitStatus

--- a/.github/workflow-scripts/Update-Licenses.ps1
+++ b/.github/workflow-scripts/Update-Licenses.ps1
@@ -1,16 +1,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+Set-StrictMode -Version Latest
+
 $filePath = 'src/LICENSE.txt'
 
 $lines = Get-Content -Path $filePath
-# .LineNumber is 1-based, so $separatorIndex naturally points one past the separator in 0-based indexing.
-$separatorIndex = ($lines | Select-String -Pattern '^-+$' | Select-Object -Skip 1 -First 1).LineNumber
-if ($null -eq $separatorIndex)
+$separatorLineNumbers = @(
+    for ($index = 0; $index -lt $lines.Count; $index++)
+    {
+        if ($lines[$index] -match '^-+$')
+        {
+            $index + 1
+        }
+    }
+)
+if ($separatorLineNumbers.Count -lt 2)
 {
     throw 'No separator line.'
 }
 
+$separatorIndex = $separatorLineNumbers[1]
 $remainingLines = $lines[$separatorIndex..($lines.Count - 1)]
 $nonBlankLines = $remainingLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 if (@($nonBlankLines).Count -eq 0)

--- a/.github/workflow-scripts/Update-ThirdPartyNotices.ps1
+++ b/.github/workflow-scripts/Update-ThirdPartyNotices.ps1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+Set-StrictMode -Version Latest
+
 $inputFile = './third-party-licenses.txt'
 $outputFile = 'src/LICENSE.txt'
 $marker = 'This file was generated with'

--- a/.github/workflow-scripts/Update-Version.ps1
+++ b/.github/workflow-scripts/Update-Version.ps1
@@ -12,6 +12,8 @@ param(
     [int]$Patch
 )
 
+Set-StrictMode -Version Latest
+
 $version = "$Major.$Minor.$Patch"
 
 function Update-FileContent


### PR DESCRIPTION
This pull request introduces several improvements to the project's PowerShell workflow and action scripts. The main changes are the addition of strict mode enforcement for better script reliability.

**Script reliability and consistency:**

* Added `Set-StrictMode -Version Latest` to all PowerShell scripts in `.github/actions` and `.github/workflow-scripts` to enforce stricter error handling and catch common scripting mistakes. [[1]](diffhunk://#diff-728eb88c235e48d05c0bff198c84d1d11195f17ef02b236654566cf7b992bea4R13) [[2]](diffhunk://#diff-999e0fd77aed9ec4597afad27de5e1ae2cf6970d6c29ffe85e986fc296ec6660R4-R5) [[3]](diffhunk://#diff-78bc4ae891935890d39ac92006761155ef8e838d96853608c3edf61806e2c6edR4-R23) [[4]](diffhunk://#diff-4d74a9db4b7a5bfb9b25c2a4dd304bf23e09b40a9bc413327e2dc439a5170d6eR4-R5) [[5]](diffhunk://#diff-f846aa6b3fdf3d5fac416265210367dcf21290e2c797605d92f7a1ced6bed66bR15-R16)=